### PR TITLE
feat: cancel clock event when kivy app stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.5.7
+
+- feat: cancel clock event when kivy app stops
+
 ## Version 0.5.6
 
 - fix: ignore data hash and render a single frame after resume

--- a/headless_kivy_pi/__init__.py
+++ b/headless_kivy_pi/__init__.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import kivy
 import numpy as np
-from kivy.app import ObjectProperty, Widget
+from kivy.app import App, ObjectProperty, Widget
 from kivy.clock import Clock
 from kivy.config import Config
 from kivy.graphics import (
@@ -305,6 +305,9 @@ class HeadlessWidget(Widget):
             True,
         )
         self.render_on_display_event()
+        App.get_running_app().bind(
+            on_stop=lambda _: self.render_on_display_event.cancel(),
+        )
 
     def add_widget(
         self: HeadlessWidget,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "headless-kivy-pi"
-version = "0.5.6"
+version = "0.5.7"
 description = "Headless renderer for Kivy framework on Raspberry Pi"
 authors = ["Sassan Haradji <sassanh@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
After exiting the Kivy app, the scheduler should stop rendering frames as all framebuffers, etc are unavailable at this stage. This is causing an issue in ubo-app when it manually triggers another tick of Clock after app is finished and FinishAction is dispatched.