### PR TITLE
refactor: avoid unnecessary scheduled calls of `render_on_display`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.5.9
+
+- refactor: make `synchronous_clock` enabled by default
+
 ## Version 0.5.8
 
 - refactor: avoid unnecessary scheduled calls of `render_on_display`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.5.8
+
+- refactor: avoid unnecessary scheduled calls of `render_on_display`
+- refactor: make `automatic_fps` enabled by default
+
 ## Version 0.5.7
 
 - feat: cancel clock event when kivy app stops

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "headless-kivy-pi"
-version = "0.5.8"
+version = "0.5.9"
 description = "Headless renderer for Kivy framework on Raspberry Pi"
 authors = ["Sassan Haradji <sassanh@gmail.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "headless-kivy-pi"
-version = "0.5.7"
+version = "0.5.8"
 description = "Headless renderer for Kivy framework on Raspberry Pi"
 authors = ["Sassan Haradji <sassanh@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Some optimizations, mostly this is to avoid unnecessary calls of `render_to_display` method. It used to call it as many times as possible using `schedule_interval` and it then decided whether a render is needed or it should return without rendering, now it is called only when needed based on current fps.