### PR TITLE
feat: render relevant parts of the screen only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.7.0
+
+- feat: render relevant parts of the screen only
+- feat: keep a copy of the raw data transferred to the display in `config._display.raw_data`
+
 ## Version 0.6.1
 
 - chore: GitHub workflow to publish pushes on `main` branch to PyPI

--- a/headless_kivy_pi/__init__.py
+++ b/headless_kivy_pi/__init__.py
@@ -32,7 +32,6 @@ from kivy.properties import ObjectProperty
 from kivy.uix.widget import Widget
 
 from headless_kivy_pi import config
-from headless_kivy_pi.constants import IS_TEST_ENVIRONMENT
 from headless_kivy_pi.display import transfer_to_display
 from headless_kivy_pi.logger import logger
 
@@ -61,7 +60,7 @@ class HeadlessWidget(Widget):
 
     def __init__(self: HeadlessWidget, **kwargs: dict[str, object]) -> None:
         """Initialize a `HeadlessWidget`."""
-        if not IS_TEST_ENVIRONMENT:
+        if not config.is_test_environment():
             config.check_initialized()
 
         self.should_ignore_hash = False
@@ -260,6 +259,7 @@ class HeadlessWidget(Widget):
         thread = Thread(
             target=transfer_to_display,
             args=(
+                (self.x, self.y, self.width, self.height),
                 data,
                 data_hash,
                 last_thread,

--- a/headless_kivy_pi/constants.py
+++ b/headless_kivy_pi/constants.py
@@ -12,9 +12,6 @@ BITS_PER_BYTE = 11
 
 # Configure the headless mode for the Kivy application and initialize the display
 
-IS_TEST_ENVIRONMENT = (
-    strtobool(os.environ.get('HEADLESS_KIVY_PI_TEST_ENVIRONMENT', 'False')) == 1
-)
 MIN_FPS = int(os.environ.get('HEADLESS_KIVY_PI_MIN_FPS', '1'))
 MAX_FPS = int(os.environ.get('HEADLESS_KIVY_PI_MAX_FPS', '32'))
 WIDTH = int(os.environ.get('HEADLESS_KIVY_PI_WIDTH', '240'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "headless-kivy-pi"
-version = "0.6.1"
+version = "0.7.0"
 description = "Headless renderer for Kivy framework on Raspberry Pi"
 authors = ["Sassan Haradji <sassanh@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
feat: keep a copy of the raw data transferred to the display in `config._display.raw_data`

This is useful for snapshot tests to snapshot exactly what is rendered on the screen.

This pull request also finalizes partial renders.